### PR TITLE
ボタンの色を変えてみました

### DIFF
--- a/nuxt/components/postDialog.vue
+++ b/nuxt/components/postDialog.vue
@@ -5,12 +5,17 @@
         <v-btn
           v-bind="attrs"
           v-on="on"
+          color="red"
           :bottom="true"
           :fixed="true"
           :right="true"
+          fab
+          dark
+          large
           @click="postDialogBool = !postDialogBool"
         >
-          タスク作成
+          <!-- タスク作成 -->
+          <v-icon dark>mdi-plus</v-icon>
         </v-btn>
       </template>
       <v-card>
@@ -54,10 +59,8 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click="postCancel"
-            >Close</v-btn
-          >
-          <v-btn color="blue darken-1" text @click="postDialogBool = false"
+          <v-btn color="red darken-2" @click="postCancel">Close</v-btn>
+          <v-btn color="green darken-1" @click="postDialogBool = false"
             >Save</v-btn
           >
         </v-card-actions>
@@ -82,10 +85,10 @@ export default {
   }),
 
   methods: {
-    postCancel(){
+    postCancel() {
       this.postDialogBool = false
       this.$store.dispatch('tasks/postAllReset')
-    }
+    },
   },
 
   computed: {


### PR DESCRIPTION
具体的には
・タスク追加ボタンを丸くし主張を激しくした
・タスク追加ダイアログのSaveとCloseの色を見てわかるようにした
です

完全に好みの問題なので、修正点があれば、どうぞ…
![image](https://user-images.githubusercontent.com/67499131/90499183-320f0800-e184-11ea-9dfa-4651b4e1ff19.png)

![image](https://user-images.githubusercontent.com/67499131/90499214-3b987000-e184-11ea-84e2-49afcdadc4bf.png)

