### PR TITLE
deadlinedateをnullでリセットするようにした

### DIFF
--- a/nuxt/store/tasks.js
+++ b/nuxt/store/tasks.js
@@ -139,8 +139,8 @@ export const actions = {
 
   postAllReset(context) {
     context.commit('setPostTitle', '')
-    context.commit('setPostDeadlineDate', '')
-    context.commit('setPostDeadlineTime', '')
+    context.commit('setPostDeadlineDate', null)
+    context.commit('setPostDeadlineTime', null)
     context.commit('setPostDescription', '')
     context.commit('setPostWeight', '')
   },


### PR DESCRIPTION
これによって、dateが設定されていないときに初期値を設定する機能が正常に動作するようになりました。