### PR TITLE
logのバリエーションを増やした

### DIFF
--- a/nuxt/store/game.js
+++ b/nuxt/store/game.js
@@ -14,7 +14,7 @@ export const state = () => ({
     'は冷凍ビームを発射！',
     'はじゃんけんを強要してきた！負けた！',
     'は石を投げつけてきた！',
-    'の精神的圧力！仕事をしろ！'
+    'の精神的圧力！仕事をしろ！',
   ],
   logCount: [],
 })
@@ -87,12 +87,13 @@ export const actions = {
     }
   },
 
-  writeDamageLog({ state, rootState, commit }) {
+  writeDamageLog({ state, rootState, commit, dispatch }) {
+    let log = state.log
     let logCount = state.logCount
     rootState.tasks.tasks.forEach((element, index) => {
       let attackRnd = Math.random()
       if (attackRnd <= 0.3) {
-        let logIndex = Math.random()*state.logVariation.length
+        let logIndex = Math.random() * state.logVariation.length
         logIndex = Math.floor(logIndex)
         log =
           element.title +

--- a/nuxt/store/game.js
+++ b/nuxt/store/game.js
@@ -64,7 +64,7 @@ export const actions = {
   writeDamageLog({ state, rootState, commit }) {
     let log = state.log
     rootState.tasks.tasks.forEach((element) => {
-      let logIndex = Math.random(state.logVariation.length)*state.logVariation.length
+      let logIndex = Math.random()*state.logVariation.length
       logIndex = Math.floor(logIndex)
       log =
         element.title +

--- a/nuxt/store/game.js
+++ b/nuxt/store/game.js
@@ -4,6 +4,19 @@ export const state = () => ({
   HP: 750000,
   maxHP: 1000000,
   log: '',
+
+  logVariation: [
+    'は火を吐いた！ファイアー！',
+    'の毒ガス攻撃！',
+    'の迫真の攻撃！',
+    'は顔からビームを発射した！',
+    'のグーパン！',
+    'は叫んで超音波を出した！ギョエェェェエ！！',
+    'は冷凍ビームを発射！',
+    'はじゃんけんを強要してきた！負けた！',
+    'は石を投げつけてきた！',
+    'の精神的圧力！仕事をしろ！'
+  ],
 })
 
 export const mutations = {
@@ -51,9 +64,11 @@ export const actions = {
   writeDamageLog({ state, rootState, commit }) {
     let log = state.log
     rootState.tasks.tasks.forEach((element) => {
+      let logIndex = Math.random(state.logVariation.length)*state.logVariation.length
+      logIndex = Math.floor(logIndex)
       log =
         element.title +
-        'の攻撃！' +
+        state.logVariation[logIndex] +
         rootState.user.name +
         'は' +
         1 +


### PR DESCRIPTION
logVariationに書かれたログがランダムで出力されます。（タスクの攻撃手段がランダムになりました）
そもそもこの機能を本当にマージするべきかという点や、ログの文章をどうするのか（増やしたり減らしたり変えたり）など、相談するべき点がいくつかあると思います。