### PR TITLE
HPが減るタイミングがランダムになるようにした

### DIFF
--- a/nuxt/store/game.js
+++ b/nuxt/store/game.js
@@ -4,6 +4,7 @@ export const state = () => ({
   HP: 750000,
   maxHP: 1000000,
   log: '',
+  logCount: [],
 })
 
 export const mutations = {
@@ -18,12 +19,31 @@ export const mutations = {
   setLog(state, log) {
     state.log = log
   },
+
+  setLogCount(state, logCount) {
+    state.logCount = logCount
+  },
+
+  addTask(state) {
+    state.logCount.push(1)
+  },
+
+  removeTask(state, index) {
+    state.logCount.splice(index, 1)
+  },
 }
 
 export const actions = {
   gameInit({ commit, dispatch }) {
     dispatch('getHP')
     commit('setLog', '')
+    dispatch('logCountInit')
+  },
+
+  logCountInit({ rootState, commit }) {
+    let logCount = []
+    rootState.tasks.tasks.forEach(() => logCount.push(1))
+    commit('setLogCount', logCount)
   },
 
   async getHP({ state, commit }) {
@@ -50,16 +70,24 @@ export const actions = {
 
   writeDamageLog({ state, rootState, commit }) {
     let log = state.log
-    rootState.tasks.tasks.forEach((element) => {
-      log =
-        element.title +
-        'の攻撃！' +
-        rootState.user.name +
-        'は' +
-        1 +
-        'のダメージを受けた！\n' +
-        log
+    let logCount = state.logCount
+    rootState.tasks.tasks.forEach((element, index) => {
+      let attackRnd = Math.random()
+      if (attackRnd <= 0.3) {
+        log =
+          element.title +
+          'の攻撃！' +
+          rootState.user.name +
+          'は' +
+          1 * logCount[index] +
+          'のダメージを受けた！\n' +
+          log
+        logCount[index] = 1
+      } else {
+        logCount[index] += 1
+      }
     })
+    commit('setLogCount', logCount)
     commit('setLog', log)
   },
 

--- a/nuxt/store/tasks.js
+++ b/nuxt/store/tasks.js
@@ -158,6 +158,7 @@ export const actions = {
             weight: post_json.weight,
           }
           commit('addTask', new_task)
+          commit('game/addTask', null, { root: true })
           dispatch('postAllReset')
         }
       })
@@ -182,6 +183,7 @@ export const actions = {
         if (res.status === 200) {
           let index = state.tasks.findIndex((element) => element.id === taskID)
           commit('removeTask', index)
+          commit('game/removeTask', index, { root: true })
         }
       })
   },


### PR DESCRIPTION
処理の詳細を説明していきます。
logCountはint型の配列です。初期値は1で、要素数は常にタスクの数と同じになるように保たれます。（そのため、mutationsにsetLogCountのほかに、addTaskとremoveTaskを追加しています。この二つはtask.jsにてTaskの数が増減した際に呼び出されます。）
writeDamageLogに大幅に処理を追加しました。新たにattackRndという変数を宣言しました。これは攻撃の間隔のランダムさをつかさどる変数で、この変数が0.3より高いとき、攻撃をためます。0.3以下の時、攻撃力（今は定数1）*ためた秒数という計算式に基づいてプレイヤーにダメージを与えます。

現在の問題は、lowerHPとの同期が取れていないこと、その都合上バックエンドとの同期も取れていないことです。（そのため、あくまでログの見た目だけの処理ということになります。）