### PR TITLE
期限一週間前のタスクが攻撃してこないようにした

### DIFF
--- a/nuxt/store/game.js
+++ b/nuxt/store/game.js
@@ -114,14 +114,23 @@ export const actions = {
       dispatch('logCountInit')
     }
     let logCount = state.logCount
-    rootState.tasks.tasks.forEach((element, index) => {
+    for (let i = 0; i < rootState.tasks.tasks.length; i++) {
+      let taskDealineOneWeekAgo = getters.judgmentTaskDealineOneWeekAgo(
+        rootState.tasks.tasks[i]
+      )
+      if(!taskDealineOneWeekAgo){
+        continue
+      }
       let attackRnd = Math.random()
       if (attackRnd <= 0.3) {
         let logIndex = Math.random() * state.logVariation.length
         logIndex = Math.floor(logIndex)
-        let damage = getters.calcDamage(element.weight, logCount[index])
+        let damage = getters.calcDamage(
+          rootState.tasks.tasks[i].weight,
+          logCount[i]
+        )
         log =
-          element.title +
+          rootState.tasks.tasks[i].title +
           state.logVariation[logIndex] +
           rootState.user.name +
           'は' +
@@ -129,11 +138,11 @@ export const actions = {
           'のダメージを受けた！\n' +
           log
         dispatch('lowerHP', damage)
-        logCount[index] = 1
+        logCount[i] = 1
       } else {
-        logCount[index] += 1
+        logCount[i] += 1
       }
-    })
+    }
     commit('setLogCount', logCount)
     if (state.dieFlag) {
       log = rootState.user.name + 'は死んでしまった！\n' + log
@@ -160,9 +169,29 @@ export const getters = {
   calcDamage: (_state, _getters, rootState) => (weight, count) => {
     let weights = rootState.tasks.weights
     let weightIndex = weights.findIndex((element) => element === weight) + 1
-    if (weightIndex === -1) {
+    if (weightIndex === 0) {
       weightIndex = 1
     }
     return weightIndex * count
+  },
+
+  judgmentTaskDealineOneWeekAgo: () => (task) => {
+    if (task.deadlineDate === '') {
+      return true
+    }
+    let taskDate = new Date(
+      parseInt(task.deadlineDate.substr(0, 4), 10),
+      parseInt(task.deadlineDate.substr(5, 2), 10) - 1,
+      parseInt(task.deadlineDate.substr(8, 2), 10),
+      parseInt(task.deadlineTime.substr(0, 2), 10),
+      parseInt(task.deadlineTime.substr(3, 2), 10),
+      0
+    )
+    let diff = taskDate.getTime() - Date.now()
+    if (diff / (1000 * 60 * 60) < 168) {
+      return true
+    } else {
+      return false
+    }
   },
 }


### PR DESCRIPTION
forEachの使用をやめました（continueを使用するため）
他の手段で、期限一週間前かどうかをcalcDamage内で判定し、期限よりも一週間以上前の時はダメージを0にし、ダメージが0ならばログに記述しないという手段も考えましたが、それだとlogCountへのカウントは継続して行われることになり、どうしても小さなズレが発生してしまうので、こちらのほうが良いと判断しました。