### PR TITLE
フォントが常にちゃんと設定されるようにした

### DIFF
--- a/nuxt/layouts/default.vue
+++ b/nuxt/layouts/default.vue
@@ -43,3 +43,9 @@ export default {
   },
 }
 </script>
+
+<style lang="scss">
+.v-application {
+  font-family: 'PixelMplus';
+}
+</style>

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -50,9 +50,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss">
-.v-application {
-  font-family: 'PixelMplus';
-}
-</style>


### PR DESCRIPTION
今までは、index以外のページ（ログインなど）で再読み込みをすると、フォントがデフォルトのものになってしまう状態でしたが、それを直しました。