### PR TITLE
タスクがちゃんと一つだけ減るようにした

### DIFF
--- a/nuxt/components/Task.vue
+++ b/nuxt/components/Task.vue
@@ -36,7 +36,6 @@ export default {
       )
       this.$store.dispatch('tasks/successTask', index)
       this.$store.commit('tasks/setTaskIDbyDeleteAnimation', index)
-      this.$store.dispatch('game/recoveryHP')
       this.$store.dispatch('game/writeSuccessLog', this.task.title)
     },
   },

--- a/nuxt/components/Task.vue
+++ b/nuxt/components/Task.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card v-if="living" :outlined="true">
+  <v-card :outlined="true">
     <v-card-title class="justify-center">
       {{ task.title }}
     </v-card-title>
@@ -26,13 +26,11 @@ export default {
   props: ['task'],
 
   data: () => ({
-    living: true,
     space: ' ',
   }),
 
   methods: {
     success: function () {
-      this.living = false
       let index = this.$store.state.tasks.tasks.findIndex(
         (element) => element.id === this.task.id
       )

--- a/nuxt/store/tasks.js
+++ b/nuxt/store/tasks.js
@@ -184,7 +184,7 @@ export const actions = {
     context.commit('setPostWeight', '')
   },
 
-  async successTask({ state, rootState, commit }, index) {
+  async successTask({ state, rootState, commit, dispatch }, index) {
     await axios
       .post(
         process.env.URL_TASKS_SUCCESS,
@@ -200,6 +200,7 @@ export const actions = {
         if (res.status === 200) {
           commit('removeTask', index)
           commit('game/removeTask', index, { root: true })
+          dispatch('game/recoveryHP', null, { root: true })
         }
       })
   },


### PR DESCRIPTION
結論から申し上げますと、こちらのミスでした（申し訳ありませんでした。）

現行の手法ですが、
データベース上でタスクを削除（を命令）→IDを-1に変更（アニメーションを開始）→tasks.jsのtasksからタスクが削除される→一秒後、モンスター専用tasksでも削除される（アニメーション終了）
という流れで動いています。
tasks.jsのtasksからタスクが削除されるまでの時間はごくわずかなものであり、わざわざlivingで管理する必要はありません。

つまり、livingの存在そのものを削除すればよいというだけでした。（最初に気が付かなかったのが、謎）